### PR TITLE
_metadata_from_built_wheel: pass metadata_directory=None

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+v1.5.0 - (2023-01-17)
+---------------------
+- When getting metadata from a built wheel, do not pass ``metadata_directory``
+  to ``build_wheel``, which forces the backend to generate the metadata - by :user:`masenf`.
+  (`#47 <https://github.com/tox-dev/pyproject-api/issues/47>`_)
+
 v1.4.0 - (2022-01-04)
 ---------------------
 - Add minimal CLI for debugging

--- a/src/pyproject_api/_frontend.py
+++ b/src/pyproject_api/_frontend.py
@@ -453,7 +453,7 @@ class Frontend(ABC):
             wheel_result = getattr(self, cmd)(
                 wheel_directory=wheel_directory,
                 config_settings=config_settings,
-                metadata_directory=metadata_directory,
+                metadata_directory=None,  # let the backend populate the metadata
             )
             wheel = wheel_result.wheel
             if not wheel.exists():

--- a/tests/demo_pkg_inline/build.py
+++ b/tests/demo_pkg_inline/build.py
@@ -20,6 +20,8 @@ wheel = "{}/WHEEL".format(dist_info)
 record = "{}/RECORD".format(dist_info)
 content = {
     logic: "def do():\n    print('greetings from {}')".format(name),
+}
+metadata = {
     metadata: """
         Metadata-Version: 2.1
         Name: {}
@@ -62,6 +64,16 @@ def build_wheel(wheel_directory, metadata_directory=None, config_settings=None):
     with ZipFile(path, "w") as zip_file_handler:
         for arc_name, data in content.items():  # pragma: no branch
             zip_file_handler.writestr(arc_name, dedent(data).strip())
+        if metadata_directory is not None:
+            for sub_directory, _, filenames in os.walk(metadata_directory):
+                for filename in filenames:
+                    zip_file_handler.write(
+                        os.path.join(metadata_directory, sub_directory, filename),
+                        os.path.join(sub_directory, filename),
+                    )
+        else:
+            for arc_name, data in metadata.items():  # pragma: no branch
+                zip_file_handler.writestr(arc_name, dedent(data).strip())
     print("created wheel {}".format(path))
     return base_name
 


### PR DESCRIPTION
### Instruct the backend to generate the metadata when building the wheel.

After build_wheel returns, `_metadata_from_built_wheel` extracts the metadata into the passed `metadata_directory` so subsequent calls to build_wheel (if made), should have a good copy of the metadata in the place they expect to find it.

Fix #47

## Testing

Updating the demo_pkg_inline build backend to "repect-the-PEP" and it actually exposed this bug in the existing tests. With the fix, these tests do not show errors

<details>
  <summary>Show output before and after</summary>

### Before

```
masen@asmbp21 pyproject-api % tox -e py311 -- -k "not python_2"
.pkg: _optional_hooks> python /opt/homebrew/lib/python3.11/site-packages/pyproject_api/_backend.py True hatchling.build
.pkg: get_requires_for_build_editable> python /opt/homebrew/lib/python3.11/site-packages/pyproject_api/_backend.py True hatchling.build
.pkg: get_requires_for_build_wheel> python /opt/homebrew/lib/python3.11/site-packages/pyproject_api/_backend.py True hatchling.build
.pkg: build_wheel> python /opt/homebrew/lib/python3.11/site-packages/pyproject_api/_backend.py True hatchling.build
py311: install_package> python -I -m pip install --force-reinstall --no-deps /Users/masen/code/tox-dev/pyproject-api/.tox/.tmp/package/17/pyproject_api-1.4.1.dev3+gb9bcf88-py3-none-any.whl
py311: commands[0]> pytest --color=yes -k 'not python_2'
==================================================== test session starts ====================================================
platform darwin -- Python 3.11.1, pytest-7.2.1, pluggy-1.0.0
cachedir: .tox/py311/.pytest_cache
rootdir: /Users/masen/code/tox-dev/pyproject-api
plugins: mock-3.10.0, cov-4.0.0
collected 54 items / 1 deselected / 53 selected                                                                             

tests/test_backend.py .....                                                                                           [  9%]
tests/test_frontend.py ....F.................F...                                                                     [ 58%]
tests/test_frontend_setuptools.py ..........                                                                          [ 77%]
tests/test_main.py .......                                                                                            [ 90%]
tests/test_util.py ....                                                                                               [ 98%]
tests/test_version.py .                                                                                               [100%]

========================================================= FAILURES ==========================================================
_______________________________________________ test_backend_no_prepare_wheel _______________________________________________

tmp_path = PosixPath('/private/var/folders/t0/429jjwvn6kq65x52rgcm7c9h0000gp/T/pytest-of-masen/pytest-385/test_backend_no_prepare_wheel0')
demo_pkg_inline = PosixPath('/Users/masen/code/tox-dev/pyproject-api/tests/demo_pkg_inline')

    def test_backend_no_prepare_wheel(tmp_path: Path, demo_pkg_inline: Path) -> None:
        frontend = SubprocessFrontend(*SubprocessFrontend.create_args_from_folder(demo_pkg_inline)[:-1])
>       result = frontend.prepare_metadata_for_build_wheel(tmp_path)

tests/test_frontend.py:71: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.tox/py311/lib/python3.11/site-packages/pyproject_api/_frontend.py:338: in prepare_metadata_for_build_wheel
    basename, err, out = self._metadata_from_built_wheel(config_settings, metadata_directory, "build_wheel")
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pyproject_api._via_fresh_subprocess.SubprocessFrontend object at 0x10477f510>, config_settings = None
metadata_directory = PosixPath('/private/var/folders/t0/429jjwvn6kq65x52rgcm7c9h0000gp/T/pytest-of-masen/pytest-385/test_backend_no_prepare_wheel0')
cmd = 'build_wheel'

    def _metadata_from_built_wheel(
        self, config_settings: ConfigSettings | None, metadata_directory: Path | None, cmd: str
    ) -> tuple[str, str, str]:
        with self._wheel_directory() as wheel_directory:
            wheel_result = getattr(self, cmd)(
                wheel_directory=wheel_directory,
                config_settings=config_settings,
                metadata_directory=metadata_directory,
            )
            wheel = wheel_result.wheel
            if not wheel.exists():
                raise RuntimeError(f"missing wheel file return by backed {wheel!r}")
            out, err = wheel_result.out, wheel_result.err
            extract_to = str(metadata_directory)
            basename = None
            with ZipFile(str(wheel), "r") as zip_file:
                for name in zip_file.namelist():  # pragma: no branch
                    path = Path(name)
                    if path.parts[0].endswith(".dist-info"):
                        basename = path.parts[0]
                        zip_file.extract(name, extract_to)
            if basename is None:  # pragma: no branch
>               raise RuntimeError(f"no .dist-info found inside generated wheel {wheel}")
E               RuntimeError: no .dist-info found inside generated wheel /var/folders/t0/429jjwvn6kq65x52rgcm7c9h0000gp/T/tmpu9d2s0c0/demo_pkg_inline-1.0.0-py3-none-any.whl

.tox/py311/lib/python3.11/site-packages/pyproject_api/_frontend.py:471: RuntimeError
____________________________________________ test_backend_prepare_editable_miss _____________________________________________

tmp_path = PosixPath('/private/var/folders/t0/429jjwvn6kq65x52rgcm7c9h0000gp/T/pytest-of-masen/pytest-385/test_backend_prepare_editable_0')
demo_pkg_inline = PosixPath('/Users/masen/code/tox-dev/pyproject-api/tests/demo_pkg_inline')
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x104701310>

    def test_backend_prepare_editable_miss(tmp_path: Path, demo_pkg_inline: Path, monkeypatch: pytest.MonkeyPatch) -> None:
        monkeypatch.delenv("HAS_PREPARE_EDITABLE", raising=False)
        monkeypatch.delenv("BUILD_EDITABLE_BAD", raising=False)
        frontend = SubprocessFrontend(*SubprocessFrontend.create_args_from_folder(demo_pkg_inline)[:-1])
>       result = frontend.prepare_metadata_for_build_editable(tmp_path)

tests/test_frontend.py:267: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.tox/py311/lib/python3.11/site-packages/pyproject_api/_frontend.py:371: in prepare_metadata_for_build_editable
    basename, err, out = self._metadata_from_built_wheel(config_settings, metadata_directory, "build_editable")
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pyproject_api._via_fresh_subprocess.SubprocessFrontend object at 0x1047000d0>, config_settings = None
metadata_directory = PosixPath('/private/var/folders/t0/429jjwvn6kq65x52rgcm7c9h0000gp/T/pytest-of-masen/pytest-385/test_backend_prepare_editable_0')
cmd = 'build_editable'

    def _metadata_from_built_wheel(
        self, config_settings: ConfigSettings | None, metadata_directory: Path | None, cmd: str
    ) -> tuple[str, str, str]:
        with self._wheel_directory() as wheel_directory:
            wheel_result = getattr(self, cmd)(
                wheel_directory=wheel_directory,
                config_settings=config_settings,
                metadata_directory=metadata_directory,
            )
            wheel = wheel_result.wheel
            if not wheel.exists():
                raise RuntimeError(f"missing wheel file return by backed {wheel!r}")
            out, err = wheel_result.out, wheel_result.err
            extract_to = str(metadata_directory)
            basename = None
            with ZipFile(str(wheel), "r") as zip_file:
                for name in zip_file.namelist():  # pragma: no branch
                    path = Path(name)
                    if path.parts[0].endswith(".dist-info"):
                        basename = path.parts[0]
                        zip_file.extract(name, extract_to)
            if basename is None:  # pragma: no branch
>               raise RuntimeError(f"no .dist-info found inside generated wheel {wheel}")
E               RuntimeError: no .dist-info found inside generated wheel /var/folders/t0/429jjwvn6kq65x52rgcm7c9h0000gp/T/tmp2poocpy_/demo_pkg_inline-1.0.0-py3-none-any.whl

.tox/py311/lib/python3.11/site-packages/pyproject_api/_frontend.py:471: RuntimeError
================================================== short test summary info ==================================================
FAILED tests/test_frontend.py::test_backend_no_prepare_wheel - RuntimeError: no .dist-info found inside generated wheel /var/folders/t0/429jjwvn6kq65x52rgcm7c9h0000gp/T/tmpu9d2s0c0/de...
FAILED tests/test_frontend.py::test_backend_prepare_editable_miss - RuntimeError: no .dist-info found inside generated wheel /var/folders/t0/429jjwvn6kq65x52rgcm7c9h0000gp/T/tmp2poocpy_/de...
======================================== 2 failed, 51 passed, 1 deselected in 2.52s =========================================
py311: exit 1 (2.67 seconds) /Users/masen/code/tox-dev/pyproject-api> pytest --color=yes -k 'not python_2' pid=56677
.pkg: _exit> python /opt/homebrew/lib/python3.11/site-packages/pyproject_api/_backend.py True hatchling.build
  py311: FAIL code 1 (3.06=setup[0.38]+cmd[2.67] seconds)
  evaluation failed :( (3.08 seconds)
```

### After

```
masen@asmbp21 pyproject-api % tox -e py311 -- -k "not python_2"     
.pkg: _optional_hooks> python /opt/homebrew/lib/python3.11/site-packages/pyproject_api/_backend.py True hatchling.build
.pkg: get_requires_for_build_editable> python /opt/homebrew/lib/python3.11/site-packages/pyproject_api/_backend.py True hatchling.build
.pkg: get_requires_for_build_wheel> python /opt/homebrew/lib/python3.11/site-packages/pyproject_api/_backend.py True hatchling.build
.pkg: build_wheel> python /opt/homebrew/lib/python3.11/site-packages/pyproject_api/_backend.py True hatchling.build
py311: install_package> python -I -m pip install --force-reinstall --no-deps /Users/masen/code/tox-dev/pyproject-api/.tox/.tmp/package/18/pyproject_api-1.4.1.dev4+geb12d0f-py3-none-any.whl
py311: commands[0]> pytest --color=yes -k 'not python_2'
==================================================== test session starts ====================================================
platform darwin -- Python 3.11.1, pytest-7.2.1, pluggy-1.0.0
cachedir: .tox/py311/.pytest_cache
rootdir: /Users/masen/code/tox-dev/pyproject-api
plugins: mock-3.10.0, cov-4.0.0
collected 54 items / 1 deselected / 53 selected                                                                             

tests/test_backend.py .....                                                                                           [  9%]
tests/test_frontend.py ..........................                                                                     [ 58%]
tests/test_frontend_setuptools.py ..........                                                                          [ 77%]
tests/test_main.py .......                                                                                            [ 90%]
tests/test_util.py ....                                                                                               [ 98%]
tests/test_version.py .                                                                                               [100%]

============================================= 53 passed, 1 deselected in 2.50s ==============================================
.pkg: _exit> python /opt/homebrew/lib/python3.11/site-packages/pyproject_api/_backend.py True hatchling.build
  py311: OK (3.04=setup[0.39]+cmd[2.65] seconds)
  congratulations :) (3.07 seconds)
```

</details>