### PR TITLE
docs: set html_last_updated_fmt to format string

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ extensions = [
 master_doc, source_suffix = "index", ".rst"
 
 html_theme = "furo"
-html_title, html_last_updated_fmt = "pyproject-api docs", datetime.now().isoformat()
+html_title, html_last_updated_fmt = "pyproject-api docs", "%Y-%m-%dT%H:%M:%S"
 pygments_style, pygments_dark_style = "sphinx", "monokai"
 
 autoclass_content, autodoc_typehints = "both", "none"


### PR DESCRIPTION
According to the Sphinx documentation and source code, html_last_updated_fmt is supposed to be a strftime()-like format string, not a literal string with a date.

Instead of datetime.now().isoformat, set this to the equivalent format string (sans microseconds, as Sphinx does not support %f).

This is a no-op generally. However, unlike our implementation here, Sphinx's date generation obeys SOURCE_DATE_EPOCH, which means that the builds will now be able to be built reproducibly.

Fixes #53