### PR TITLE
docs: remove (dynamic) years from copyright

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-from datetime import datetime
-
 from pyproject_api import __version__
 
 project = name = "pyproject_api"
 company = "tox-dev"
-copyright = f"2021-{datetime.today().year}, {company}"
+copyright = f"{company}"
 version, release = __version__, __version__.split("+")[0]
 
 extensions = [


### PR DESCRIPTION
Setting copyright programatically to a range up to datetime.today() is legally dubious. It effectively signals that the copyright changes/extends whenever a downstream (perhaps even not holding no copyright of their own) builds the documentation, rather than when the code was authored. I do not believe this to be the case in any jurisdiction.

Rather than replace it with a static year (2023 currently) and then keep updating it on a yearly basis, remove the years altogether, as they serve little purpose: the dates are readily available through git, changelogs, PyPI etc. This follows what other projects have done or are in the process of doing as well; for example, see:
  https://daniel.haxx.se/blog/2023/01/08/copyright-without-years/
  https://hynek.me/til/copyright-years/

As a side-effect and primary motivation for this commit, this resolves a rather small build reproducibility (FTBR) issue, where builds in different years would yield different outputs.