### PR TITLE
Fix metadata_from_built only extracts one of the dist info files

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,10 @@
 Release History
 ===============
 
+v1.6.1 - (2023-08-29)
+---------------------
+- Fix :meth:`pyproject_api.Frontend.metadata_from_built` only extracts one of the dist info files.
+
 v1.6.0 - (2023-08-29)
 ---------------------
 - Remove ``build_<wheel|editable>`` from ``prepare_metadata_for_build_<wheel|editable>`` to allow separate config

--- a/src/pyproject_api/_frontend.py
+++ b/src/pyproject_api/_frontend.py
@@ -480,7 +480,6 @@ class Frontend(ABC):
                     if root.endswith(".dist-info"):
                         basename = root
                         zip_file.extract(name, extract_to)
-                        break
         if basename is None:  # pragma: no branch
             msg = f"no .dist-info found inside generated wheel {wheel}"
             raise RuntimeError(msg)

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -192,6 +192,7 @@ def test_metadata_from_built_wheel(
     monkeypatch.chdir(tmp_path)
     path, out, err = frontend.metadata_from_built(tmp_path, target)
     assert path == tmp_path / "demo_pkg_inline-1.0.0.dist-info"
+    assert {p.name for p in path.iterdir()} == {"top_level.txt", "WHEEL", "RECORD", "METADATA"}
     assert f" build_{target}" in out
     assert not err
 


### PR DESCRIPTION
Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>
