### PR TITLE
Fix the RTD docs links from PyPI title and badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# [`pyproject-api`](https://pyproject-api.readthedocs.io/en/latest/)
+# [`pyproject-api`][RTD]
 
 [![PyPI](https://img.shields.io/pypi/v/pyproject-api?style=flat-square)](https://pypi.org/project/pyproject-api/)
 [![Supported Python
 versions](https://img.shields.io/pypi/pyversions/pyproject-api.svg)](https://pypi.org/project/pyproject-api/)
 [![Downloads](https://static.pepy.tech/badge/pyproject-api/month)](https://pepy.tech/project/pyproject-api)
 [![check](https://github.com/tox-dev/pyproject-api/actions/workflows/check.yaml/badge.svg)](https://github.com/tox-dev/pyproject-api/actions/workflows/check.yaml)
-[![Documentation Status](https://readthedocs.org/projects/pyproject-api/badge/?version=latest)](https://pyproject-api.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/pyproject-api/badge/?version=latest)][RTD]
+
+[RTD]: https://pyproject-api.rtfd.io


### PR DESCRIPTION
This shows up on GH and PyPI, being a part of the core packaging metadata. The currently present link is broken and shows an HTTP 404 Not Found. The patch fixes that. The change is [handwritten by a human](https://github.com/sponsors/webknjaz).

It is similar to but *different* from #290 which requires elevated admin-level in-repo privileges and probably cannot be automated (though one could attempt having a pet agent use GH CLI to handle that I suppose).