### PR TITLE
📄 docs: publish llms.txt from the docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,7 @@
 # ruff:ignore[undocumented-public-module]
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 from sphinx.domains.python import PythonDomain
@@ -19,6 +20,7 @@ project_copyright = f"{company}"
 version, release = __version__, __version__.split("+")[0]
 
 extensions = [
+    "sphinx_llm.txt",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.extlinks",
     "sphinx.ext.autodoc",
@@ -71,3 +73,6 @@ def setup(app: Sphinx) -> None:  # ruff:ignore[undocumented-public-function]
             return super().resolve_xref(env, fromdocname, builder, type, target, node, contnode)
 
     app.add_domain(PatchedPythonDomain, override=True)
+
+
+markdown_http_base = os.environ.get("READTHEDOCS_CANONICAL_URL", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ type = [
 docs = [
   "furo>=2025.9.25",
   "sphinx-autodoc-typehints>=3.5.1",
+  "sphinx-llm>=0.4.1",
 ]
 lint = [
   "pre-commit-uv>=4.2",


### PR DESCRIPTION
The [sphinx-llm](https://github.com/NVIDIA/sphinx-llm) extension emits `llms.txt` ([llmstxt.org](https://llmstxt.org/)), `llms-full.txt`, and a markdown twin of each page during the HTML build; Read the Docs serves `llms.txt` from the docs domain root ([announcement](https://about.readthedocs.com/blog/2026/02/llms-txt-support/)). Plain markdown lets agents read the docs without rendering themed, JavaScript-dependent HTML. `markdown_http_base` keeps the sitemap links absolute so they resolve from the domain root.
